### PR TITLE
GitHub workflow to run radae no_py branch tests on radae_nopy

### DIFF
--- a/.github/workflows/run_ctest.yml
+++ b/.github/workflows/run_ctest.yml
@@ -1,0 +1,76 @@
+name: ctests
+on: [push]
+
+jobs:
+  run_ctests:
+    name: Running ctests
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-22.04, ubuntu-22.04-arm]
+        python-version: ["3.10"]
+
+    steps:
+      - name: Checkout radae_nopy code
+        uses: actions/checkout@v4
+        with:
+          path: ${{github.workspace}}/radae_nopy
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+
+      - name: Install system packages
+        shell: bash
+        run: |
+          sudo apt update
+          sudo apt install octave octave-common octave-signal sox cmake git python3.10-dev
+
+      - name: Install python packages
+        shell: bash
+        run: |
+          pip3 install torch numpy matplotlib tqdm
+
+      - name: Install codec2-dev
+        shell: bash
+        working-directory: /home/runner/
+        run: |
+          git clone https://github.com/drowe67/codec2-dev.git
+          cd codec2-dev
+          mkdir build_linux
+          cd build_linux
+          cmake -DUNITTEST=1 ..
+          make ch mksine tlininterp
+
+      - name: Build radae_nopy
+        shell: bash
+        working-directory: ${{github.workspace}}/radae_nopy
+        run: |
+          mkdir build
+          cd build
+          cmake ..
+          make
+
+      - name: Checkout radae (dr_nopy branch)
+        uses: actions/checkout@v4
+        with:
+          repository: drowe67/radae
+          ref: dr_nopy
+          path: ${{github.workspace}}/radae
+
+      - name: Build radae
+        shell: bash
+        working-directory: ${{github.workspace}}/radae
+        run: |
+          mkdir build
+          cd build
+          cmake -DRADAE_NOPY_BUILD_DIR=${{github.workspace}}/radae_nopy/build ..
+          make
+
+      - name: Run ctests
+        shell: bash
+        working-directory: ${{github.workspace}}/radae/build
+        run: |
+          ctest -V --output-on-failure -R radae_nopy


### PR DESCRIPTION
@peterbmarks @tmiw - automagically run tests every time a change is made to the radae_nopy repo.

@peterbmarks - you will have to enable these tests in the GitHub GUI, instructions on line or ask Claude.
