### PR TITLE
EOO: Apply pilot gain/tanh after IDFT.

### DIFF
--- a/src/rade_tx.c
+++ b/src/rade_tx.c
@@ -209,14 +209,17 @@ int rade_tx_state_eoo(rade_tx_state *tx, RADE_COMP *tx_out) {
                 int bit_idx = (d * Nc + c) * 2;
                 freq_sym[c].real = tx->eoo_bits[bit_idx];
                 freq_sym[c].imag = tx->eoo_bits[bit_idx + 1];
-                if (tx->ofdm.bottleneck == 3) {
-                    freq_sym[c] = rade_tanh_limit(freq_sym[c]);
-                }
-                freq_sym[c] = rade_cscale(freq_sym[c], tx->ofdm.pilot_gain);
             }
 
             /* IDFT → time domain, insert CP, write to tx_out */
             rade_ofdm_idft(&tx->ofdm, time_sym, freq_sym);
+            for (int c = 0; c < RADE_M; c++)
+            {
+                time_sym[c] = rade_cscale(time_sym[c], tx->ofdm.pilot_gain);
+                if (tx->ofdm.bottleneck == 3) {
+                    time_sym[c] = rade_tanh_limit(time_sym[c]);
+                }
+            }
             rade_ofdm_insert_cp(&tx->ofdm, &tx_out[frame_pos * (M + Ncp)], time_sym);
         }
     }


### PR DESCRIPTION
Updates EOO TX to apply pilot gain/tanh after executing IDFT. Previously this was done before IDFT, which didn't match up with the reference Python implementation.

Relevant Python code below:

```python
    def set_eoo_bits(self, eoo_bits):
        Ns = self.Ns; Ncp = self.Ncp; M = self.M; Nc = self.Nc; Nmf = int((Ns+1)*(M+Ncp))

        eoo_syms = eoo_bits[::2] + 1j*eoo_bits[1::2]
        eoo_syms = torch.reshape(eoo_syms,(1,Ns-1,Nc))
        
        eoo_tx = torch.matmul(eoo_syms,self.Winv)
        if self.Ncp:
            eoo_tx_cp = torch.zeros((1,Ns-1,self.M+Ncp),dtype=torch.complex64)
            eoo_tx_cp[:,:,Ncp:] = eoo_tx
            eoo_tx_cp[:,:,:Ncp] = eoo_tx_cp[:,:,-Ncp:]
            eoo_tx = torch.reshape(eoo_tx_cp,(1,(Ns-1)*(self.M+Ncp)))*self.pilot_gain
            if self.bottleneck == 3:
                eoo_tx = torch.tanh(torch.abs(eoo_tx)) * torch.exp(1j*torch.angle(eoo_tx))
            self.eoo[0,2*(M+Ncp):Nmf] = eoo_tx
```

@drowe67 @peterbmarks 