### PR TITLE
fix rx buffer off-by-one introduced in 794a7c9, BPF tweak, SNR re-calibration

### DIFF
--- a/.github/workflows/run_ctest.yml
+++ b/.github/workflows/run_ctest.yml
@@ -33,31 +33,20 @@ jobs:
         run: |
           pip3 install torch numpy matplotlib tqdm
 
-      - name: Install codec2-dev
-        shell: bash
-        working-directory: /home/runner/
-        run: |
-          git clone https://github.com/drowe67/codec2-dev.git
-          cd codec2-dev
-          mkdir build_linux
-          cd build_linux
-          cmake -DUNITTEST=1 ..
-          make ch mksine tlininterp
-
       - name: Build radae_nopy
         shell: bash
         working-directory: ${{github.workspace}}/radae_nopy
         run: |
           mkdir build
           cd build
-          cmake ..
+          cmake -DCMAKE_BUILD_TYPE=Release ..
           make
 
-      - name: Checkout radae (dr_nopy branch)
+      - name: Checkout radae
         uses: actions/checkout@v4
         with:
           repository: drowe67/radae
-          ref: dr_nopy
+          ref: dr-radev2
           path: ${{github.workspace}}/radae
 
       - name: Build radae

--- a/.github/workflows/run_ctest.yml
+++ b/.github/workflows/run_ctest.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: drowe67/radae
-          ref: dr-radev2
+          ref: main
           path: ${{github.workspace}}/radae
 
       - name: Build radae

--- a/src/rade_bpf.c
+++ b/src/rade_bpf.c
@@ -87,8 +87,8 @@ void rade_bpf_process(rade_bpf *bpf, RADE_COMP *y, const RADE_COMP *x, int n) {
 
     /* Process each sample */
     for (int i = 0; i < n; i++) {
-        /* Mix down to baseband: x_bb = x * exp(-j*alpha*(i+1)) */
-        phase = rade_cmul(bpf->phase, rade_cexp(-bpf->alpha*(i+1)));
+        /* Mix down to baseband using incremental phase (avoids per-sample sinf/cosf) */
+        phase = rade_cmul(phase, phase_inc);
         RADE_COMP x_bb = rade_cmul(x[i], phase);
 
         /* Shift filter memory and add new sample */
@@ -107,9 +107,6 @@ void rade_bpf_process(rade_bpf *bpf, RADE_COMP *y, const RADE_COMP *x, int n) {
         y[i] = rade_cmul(y_bb, cconj_phase);
     }
 
-    /* Save phase state for next call
-       Normalize to prevent drift */
-    float phase_mag = rade_cabs(phase);
-    bpf->phase.real = phase.real; // / phase_mag;
-    bpf->phase.imag = phase.imag; // / phase_mag;
+    /* Save phase state for next call */
+    bpf->phase = phase;
 }

--- a/src/rade_ofdm.c
+++ b/src/rade_ofdm.c
@@ -36,6 +36,7 @@
 #include "rade_ofdm.h"
 #include <string.h>
 #include <assert.h>
+#include <stdio.h>
 
 /*---------------------------------------------------------------------------*\
                            INITIALIZATION
@@ -413,8 +414,8 @@ float rade_ofdm_pilot_eq(const rade_ofdm *ofdm, RADE_COMP *rx_sym,
     float snrdB_est = 10.0f * log10f(snr_est);
 
     /* Correction based on average of straight line fit to AWGN/MPG/MPP */
-    float m_corr = 0.8070f;
-    float c_corr = 2.513f;
+    float m_corr = 0.7650f;
+    float c_corr = 4.1343f;
     snrdB_est = (snrdB_est - c_corr) / m_corr;
 
     /* Convert to 3kHz noise bandwidth */

--- a/src/rade_rx.c
+++ b/src/rade_rx.c
@@ -173,7 +173,7 @@ int rade_rx_process(rade_rx_state *rx, float *features_out, float *eoo_out, cons
     if (rx->nin > 0)
     {
         memmove(rx->rx_buf, &rx->rx_buf[rx->nin], sizeof(RADE_COMP) * (buf_size - rx->nin));
-        memcpy(&rx->rx_buf[buf_size - rx->nin - 1], rx_samples, sizeof(RADE_COMP) * rx->nin);
+        memcpy(&rx->rx_buf[buf_size - rx->nin], rx_samples, sizeof(RADE_COMP) * rx->nin);
     }
 
     /* State machine processing */


### PR DESCRIPTION
Re https://github.com/peterbmarks/radae_nopy/issues/11

The memcpy destination in rade_rx_process() was written as:

  memcpy(&rx->rx_buf[buf_size - rx->nin - 1], ...)

This is incorrect. After the memmove shifts the buffer left by nin samples (filling positions [0..buf_size-nin-1]), the new samples must fill the remaining positions [buf_size-nin..buf_size-1]. The -1 offset caused two problems on every call:

  1. Overlap: the last memmove sample at [buf_size-nin-1] was immediately overwritten by the first new sample.
  2. Stale sample: position [buf_size-1] was never updated, permanently holding a one-frame-old value.

Fix: remove the erroneous -1 to restore the correct contiguous fill.